### PR TITLE
the arg passed to build is not the project itself

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -9,9 +9,7 @@ my $name = "Imlib2";
 my $libs = "-Wl,--no-as-needed -lImlib2";
 
 class Build is Panda::Builder {
-    method build(Pies::Project $p) {
-        my $workdir = $.resources.workdir($p);
-
+    method build(|) {
 		my $c_line = "$*VM<config><cc> -c $*VM<config><cc_shared> $*VM<config><cc_o_out>src/$name$o "
 						~ "$*VM<config><ccflags> src/$name.c";
 		my $l_line = "$*VM<config><ld> $*VM<config><ld_load_flags> $*VM<config><ldflags> "


### PR DESCRIPTION
It is a string representing the current working diretory as of now,
and it will be the same dir as an IO::Path in future.

I decided to not specify any parameters because these are not used
anyway.
