### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
 	"name" : "Imlib2",
+	"license" : "Artistic-2.0",
 	"version" : "0.0.1",
 	"description" : "Perl 6 interface to the Imlib2 image library.",
 	"author" : "Henrique Dias",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license